### PR TITLE
Closes #1; also upgraded speedtest-cli to 2.1.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 tweepy==3.8.0
-speedtest-cli==2.1.2
+speedtest-cli==2.1.3

--- a/speed_test.py
+++ b/speed_test.py
@@ -7,33 +7,34 @@ def get_speed():
     return st.download()/1000/1000, st.upload()/1000/1000
 
 def get_config():
-    config = configparser.ConfigParser()
+    config = configparser.ConfigParser(allow_no_value=True)
     config.read('twitter_api.config')
     return config
 
-def send_tweet(body):
-    config = get_config()
-    api_key = config.get('TWITTER', 'api_key')
-    api_secret = config.get('TWITTER', 'api_secret')
-    access_key = config.get('TWITTER', 'access_key')
-    access_secret = config.get('TWITTER', 'access_secret')
-    auth = tweepy.OAuthHandler(api_key, api_secret)
-    auth.set_access_token(access_key, access_secret)
+def send_tweet(body, variables):
+    auth = tweepy.OAuthHandler(variables['api_key'], variables['api_secret'])
+    auth.set_access_token(variables['access_key'], variables['access_secret'])
     api = tweepy.API(auth)
     api.update_status(body)
     
 def speed_test():
-    variables = {'pay_down': 1000,
-                 'pay_up': 40,
-                 'min_down': 750,
-                 'internet_prov': 'Comcast',
-                 'loc': 'Someplace'}
+    config = get_config()
+    variables = {'api_key': config.get('TWITTER', 'api_key'),
+                 'api_secret': config.get('TWITTER', 'api_secret'),
+                 'access_key': config.get('TWITTER', 'access_key'),
+                 'access_secret': config.get('TWITTER', 'access_secret'),
+                 'pay_down': float(config.get('TWITTER', 'pay_down')),
+                 'pay_up': float(config.get('TWITTER', 'pay_up')),
+                 'min_down': float(config.get('TWITTER', 'min_down')),
+                 'isp_handle': config.get('TWITTER', 'isp_handle'),
+                 'location': config.get('TWITTER', 'location'),
+                 'additional_message': config.get('TWITTER', 'additional_message')}
     variables['down'], variables['up'] = get_speed()
     
-    body = r"""Hey @{internet_prov} why is my internet speed {down} Mbps DOWN / {up} Mbps UP when I pay for {pay_down} Mbps DOWN / {pay_up} Mbps UP in {loc}? @ComcastCares @xfinity #comcast #speedtest""".format(**variables)
+    body = r"""Hey {isp_handle} why is my internet speed {down} Mbps DOWN / {up} Mbps UP when I pay for {pay_down} Mbps DOWN / {pay_up} Mbps UP in {location}? {additional_message}""".format(**variables)
     
     if variables['down'] <= variables['min_down']:
-        send_tweet(body)
+        send_tweet(body, variables)
         
 if __name__ == '__main__':
     speed_test()

--- a/twitter_api.config
+++ b/twitter_api.config
@@ -1,5 +1,30 @@
 [TWITTER]
-api_key=<your_stuff_here>
-api_secret=<your_stuff_here>
-access_key=<your_stuff_here>
-access_secret=<your_stuff_here>
+;Your API key. Required.
+api_key=
+
+;Your API secret key. Required.
+api_secret=
+
+;Your access key. Required.
+access_key=
+
+;Your access secret key. Required.
+access_secret=
+
+;Your ISP's advertised download speed. Required.
+pay_down=1000
+
+;Your ISP's advertised upload speed. Required.
+pay_up=1000
+
+;Minimum download speed to send tweet
+min_down=750
+
+;Your ISP's Twitter handle. Required.
+isp_handle=@Comcast
+
+;Your location. Required.
+location=New York
+
+;Message to add at the end of tweet. Optional.
+additional_message=@ComcastCares @xfinity #comcast #speedtest


### PR DESCRIPTION
I added more configs and added those to the variables dictionary.

Rather than calling `get_config()` twice, it's now called in the `speed_test()` and passed to `send_tweet()`.